### PR TITLE
fix: remove explicit agents/skills from marketplace entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,16 +57,7 @@
         "tensegrity"
       ],
       "category": "mobile",
-      "strict": false,
-      "agents": ["./agents/react-native-3d.md"],
-      "skills": [
-        "./skills/r3f-native-patterns",
-        "./skills/touch-gesture-3d",
-        "./skills/wireframe-rendering",
-        "./skills/camera-controls-mobile",
-        "./skills/skia-3d-alternative",
-        "./skills/debugging-3d-mobile"
-      ]
+      "strict": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fix plugin load error: "Plugin has conflicting manifests"

Claude Code auto-discovers agents and skills from the directory structure. Having both explicit `agents`/`skills` arrays in the marketplace entry AND auto-discovery causes a conflict.

## Changes

Remove explicit agents/skills arrays from `react-native-3d` marketplace entry to let auto-discovery work.

## Test plan

- [x] `claude plugin list` shows plugin without error
- [x] Plugin status shows "✔ enabled"

🤖 Generated with [Claude Code](https://claude.com/claude-code)