### PR TITLE
feat(code-critic): adversarial-reviewer v1.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "name": "code-critic",
       "source": "./plugins/code-critic",
       "description": "Skeptical code review agent that assumes code is wrong until proven otherwise. Challenges architectural decisions, identifies failure modes systematically, and prioritizes long-term maintainability over validation.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "Andrew Rich",
         "url": "https://github.com/smartwatermelon"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A curated collection of quality-focused plugins for Claude Code, emphasizing cri
 ## Philosophy
 
 This marketplace focuses on plugins that:
+
 - **Challenge assumptions** rather than validate them
 - **Identify failure modes** before they reach production
 - **Prioritize long-term maintainability** over short-term convenience
@@ -32,18 +33,20 @@ claude plugin install --all smartwatermelon-marketplace
 
 ### Code Critic
 
-**Status**: Stable v1.0.0
+**Status**: Stable v1.2.0
 **Category**: Quality / Code Review
 
 Skeptical code review agent that assumes code is wrong until proven otherwise. Unlike validation-focused reviewers, Code Critic challenges architectural decisions, identifies failure modes, and prioritizes long-term maintainability.
 
 **Features**:
+
 - Reviews code hierarchy: Purpose → Architecture → Failure Modes → Maintenance → Implementation
 - Challenges assumptions and asks "why" before "how"
 - Identifies race conditions, error handling gaps, and scalability issues
 - Integrates with git hooks for automated review
 
 **When to use**:
+
 - Security-critical code (auth, payments, data handling)
 - Architectural changes
 - Complex business logic
@@ -52,6 +55,7 @@ Skeptical code review agent that assumes code is wrong until proven otherwise. U
 **Documentation**: [plugins/code-critic/README.md](plugins/code-critic/README.md)
 
 **Install**:
+
 ```bash
 claude plugin install code-critic@smartwatermelon-marketplace
 ```
@@ -97,6 +101,7 @@ plugins/
 ### Quality Standards
 
 Plugins in this marketplace must:
+
 - Have comprehensive documentation
 - Include usage examples
 - Specify clear use cases (when to use, when not to use)
@@ -109,12 +114,14 @@ Plugins in this marketplace must:
 ### Why "SmartWatermelon"?
 
 SmartWatermelon represents the intersection of:
+
 - **Smart**: Intelligent, thoughtful tooling that enhances developer capabilities
 - **Watermelon**: Fresh perspective, cutting through to the core of problems
 
 ### Quality Over Quantity
 
 This marketplace emphasizes quality over quantity. Each plugin is:
+
 - **Purpose-driven**: Solves a specific, real problem
 - **Well-documented**: Clear usage guide with examples
 - **Battle-tested**: Used in real projects
@@ -123,6 +130,7 @@ This marketplace emphasizes quality over quantity. Each plugin is:
 ### Not Just Another Marketplace
 
 Unlike general-purpose marketplaces, SmartWatermelon focuses on:
+
 1. **Critical thinking tools** - Plugins that challenge and improve your thinking
 2. **Quality assurance** - Tools that catch problems before they ship
 3. **Developer discipline** - Workflows that enforce best practices
@@ -131,7 +139,7 @@ Unlike general-purpose marketplaces, SmartWatermelon focuses on:
 
 - **Issues**: [GitHub Issues](https://github.com/smartwatermelon/smartwatermelon-marketplace/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/smartwatermelon/smartwatermelon-marketplace/discussions)
-- **Contact**: andrew.rich@gmail.com
+- **Contact**: <andrew.rich@gmail.com>
 
 ## License
 
@@ -147,5 +155,5 @@ Inspired by the philosophy that good tools challenge us to be better developers.
 
 ---
 
-**Latest Version**: 1.0.0
-**Last Updated**: 2026-01-15
+**Latest Version**: 1.2.0
+**Last Updated**: 2026-02-11

--- a/plugins/code-critic/.claude-plugin/plugin.json
+++ b/plugins/code-critic/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-critic",
   "description": "Skeptical code review agent that assumes code is wrong until proven otherwise. Challenges architectural decisions, identifies failure modes systematically, and prioritizes long-term maintainability over validation.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Andrew Rich",
     "email": "andrew.rich@gmail.com"
@@ -15,6 +15,7 @@
     "critical-feedback",
     "code-quality",
     "maintainability",
-    "git-hooks"
+    "git-hooks",
+    "security"
   ]
 }

--- a/plugins/code-critic/README.md
+++ b/plugins/code-critic/README.md
@@ -11,6 +11,7 @@ Code Critic is a skeptical code review agent inspired by senior engineers who've
 Your job is not to validate the developer's approach. Your job is to find what's wrong, what will break, and what will become someone else's problem in 18 months.
 
 **Assumptions:**
+
 - The developer may be solving the wrong problem
 - Requirements may be incomplete or misunderstood
 - "It works" is not the same as "it's correct"
@@ -47,6 +48,7 @@ Use the Task tool with subagent_type="adversarial-review:adversarial-reviewer"
 ```
 
 Example conversation:
+
 ```
 User: I've implemented the user authentication system
 Claude: Let me use the adversarial-review agent to review this implementation
@@ -71,7 +73,7 @@ claude --agent adversarial-reviewer -p "Review this implementation" < src/auth/l
 
 ## When to Use Code Critic
 
-### ✅ Use Code Critic When:
+### ✅ Use Code Critic When
 
 - Implementing security-critical code (auth, payments, data handling)
 - Making architectural decisions
@@ -80,10 +82,10 @@ claude --agent adversarial-reviewer -p "Review this implementation" < src/auth/l
 - You want genuinely critical feedback, not validation
 - Changes affect system boundaries or contracts
 
-### ❌ Use Standard Review When:
+### ❌ Use Standard Review When
 
 - Making small, obvious bug fixes
-- Writing tests
+- Writing tests (unless they encode architectural assumptions)
 - Updating documentation
 - Refactoring with comprehensive test coverage
 - You need quick validation of straightforward changes
@@ -129,6 +131,19 @@ Code Critic addresses concerns in this order:
 - **Domain awareness**: Adjusts review lens for backend, frontend, data pipelines, APIs, and tests
 - **Context and scope**: Explicit instructions to read surrounding code and trace data flow before forming opinions
 - **Honest calibration**: Good code gets recognized with the same rigor as bad code — no manufactured criticism
+- **Activation Criteria removed**: Usage guidance now lives in README and USAGE.md, not in the agent prompt
+
+## What's New in v1.2.0
+
+- **Observability checklist**: New failure mode category — can you tell when this is broken in production?
+- **Insufficient Context verdict**: Fourth verdict option for partial reviews where context is missing
+- **Diff-awareness**: Guidance for adapting review depth to diffs vs. full files vs. snippets
+- **Output length calibration**: Concise for git hooks, thorough for interactive review
+- **Confidence signaling**: Distinguishes confirmed findings from pattern-based suspicions
+- **Domain Awareness repositioned**: Now sets the review lens before the hierarchy is applied
+- **Configuration/prompts/IaC domain**: New domain-specific guidance for reviewing config and prompt files
+- **Honest calibration restored**: "Genuinely good code is rare" qualifier reinstated
+- **Documentation fixes**: Examples updated to match defined response format, severity/verdict duplication removed, `--no-verify` references replaced with safe alternatives
 
 ## What Code Critic is NOT
 


### PR DESCRIPTION
## Summary

- Address all 14 findings from the triple-agent self-review (adversarial, architect, code-reviewer)
- Improve agent prompt with observability checklist, Insufficient Context verdict, diff-awareness, output length calibration, confidence signaling, and Configuration/IaC domain
- Fix documentation inconsistencies: examples match response format, severity/verdict deduplication, safe alternatives to hook bypass
- Sync versions to 1.2.0 across all manifests

## Changes

### Agent prompt (`adversarial-reviewer.md`)
- **Observability & Operability** added to failure mode checklist
- **Insufficient Context** added as fourth verdict option
- **Review Context Awareness** section for diff/file/snippet handling
- **Output length calibration** (concise for hooks, thorough for interactive)
- **Confidence signaling** added to Behavioral Rules
- **Domain Awareness** moved before Review Hierarchy (sets the review lens early)
- **Configuration/prompts/IaC** domain added
- "Genuinely good code is rare" qualifier restored

### Documentation
- USAGE.md examples rewritten to use defined response format (Summary/Critical Issues/Concerns/Questions/Verdict)
- USAGE.md severity/verdict definitions replaced with agent prompt reference (single source of truth)
- GIT_HOOKS.md: all skip-review references replaced with safe alternatives (retry, split commits, increase timeout)
- README: test guidance clarified, v1.1.0 and v1.2.0 changelogs added
- Root README.md version updated to 1.2.0
- GIT_HOOKS.md TOC link fragments fixed

### Metadata
- `plugin.json`: add "security" keyword, bump to 1.2.0
- `marketplace.json`: bump to 1.2.0

## Test plan

- [x] Triple-agent self-review (adversarial, architect, code-reviewer) — all passed
- [x] Pre-commit hooks pass (markdownlint, prettier)
- [x] Code-reviewer hook pass
- [x] Adversarial-reviewer hook pass
- [x] Version numbers consistent (1.2.0 in marketplace.json, plugin.json, root README)
- [x] Keywords synced across plugin.json and marketplace.json
- [x] No remaining skip-review recommendations in GIT_HOOKS.md
- [x] USAGE.md examples match defined response format

🤖 Generated with [Claude Code](https://claude.com/claude-code)