### PR TITLE
chore: trim code-critic and ci-workflows skill descriptions

### DIFF
--- a/plugins/ci-workflows/skills/post-push-loop/SKILL.md
+++ b/plugins/ci-workflows/skills/post-push-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: post-push-loop
-description: "Use after pushing a PR branch to autonomously monitor CI, fetch remote review findings, generate fixes, and iterate until CI is clean or a hard decision is needed. Invoke as: /post-push-loop [pr-number]"
+description: "Use after pushing a PR to autonomously monitor CI, fetch review findings, and iterate fixes until clean. Invoke as: /post-push-loop [pr-number]"
 ---
 
 # Post-Push Loop
@@ -67,7 +67,7 @@ Timeout: if `CI_STATE` has not resolved after 15 minutes, escalate with reason
 Parse script output using this exact decision table — evaluate in order:
 
 | CI_STATE | FINDING lines present? | Action |
-|---|---|---|
+| --- | --- | --- |
 | `SUCCESS` | No | **Exit: Success** |
 | `SUCCESS` | Yes | Proceed to Phase 3 |
 | `FAILURE` | Either | Proceed to Phase 3 |

--- a/plugins/code-critic/agents/adversarial-reviewer.md
+++ b/plugins/code-critic/agents/adversarial-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: adversarial-reviewer
-description: Skeptical senior engineer who reviews code assuming it's wrong until proven otherwise. Challenges architectural decisions, identifies failure modes systematically, and prioritizes long-term maintainability over developer feelings. Use when you want genuinely critical feedback rather than validation.
+description: Single-pass skeptical review — assumes the code is wrong until proven otherwise, challenges assumptions and architectural decisions. Use when you want critical feedback, not validation.
 model: opus
 ---
 


### PR DESCRIPTION
## Summary
- Trims `adversarial-reviewer`'s description (300 -> ~145 chars), also clarifying it's a single-pass review to distinguish it from comprehensive-review's multi-agent `full-review`.
- Trims `post-push-loop`'s description (204 -> ~145 chars).
- Both keep their trigger condition intact.

https://claude.ai/code/session_215f11d6-fd80-488b-9ae8-2e0fc0f51f9d