### PR TITLE
docs(react-native-3d): document __r3f deletion error patterns and fixes

### DIFF
--- a/plugins/react-native-3d/skills/debugging-3d-mobile/SKILL.md
+++ b/plugins/react-native-3d/skills/debugging-3d-mobile/SKILL.md
@@ -63,6 +63,13 @@ Is the Canvas rendering anything?
     │   ├─ Check: Is there a blocking View/component?
     │   └─ Try: Add onPointerMissed to Canvas
     │
+    ├─ "Cannot delete property '__r3f' of undefined"?
+    │   ├─ Check: Using locationX/locationY, not clientX/clientY?
+    │   ├─ Check: Does useMemo return a Three.js object instead of a primitive array?
+    │   ├─ Check: Any module-level `new Vector3()`/`new Quaternion()` constants?
+    │   ├─ Check: Does state management replace object refs instead of mutating?
+    │   └─ See: "Issue: Cannot delete property '__r3f' of undefined" below
+    │
     └─ Performance issues?
         ├─ Check: Are you creating objects every render?
         ├─ Check: How many draw calls?
@@ -220,6 +227,113 @@ function RaycastDebugger() {
     {/* UI overlay */}
   </View>
 </View>
+```
+
+## Issue: "Cannot delete property '__r3f' of undefined"
+
+### What It Looks Like
+
+```
+TypeError: Cannot delete property '__r3f' of undefined
+```
+
+This fires during a re-render or unmount cleanup — not on initial mount. It often shows up mid-interaction (touch, drag, physics update) rather than at a predictable location in your code.
+
+### Why It Happens
+
+R3F attaches internal `__r3f` bookkeeping metadata directly onto the Three.js objects (meshes, geometries, materials, Vector3/Quaternion instances, etc.) you pass as props. R3F's cleanup effect later tries to `delete` that `__r3f` property when the object is replaced or the component unmounts.
+
+If the *reference* to that Three.js object changes or gets orphaned between renders — a new object is created, state replaces it wholesale, or it was never uniquely owned by that component — R3F's cleanup tries to delete `__r3f` off an object it no longer owns (or that was never fully attached), and the property lookup resolves to `undefined`. Hence: "Cannot delete property `__r3f` of undefined."
+
+The fix in every case below is the same principle: keep Three.js object *references* stable across renders, and don't let unrelated bugs (like broken touch coordinates) put components into inconsistent re-render states that trigger this cleanup path.
+
+### Root Cause 1: Touch Coordinate Mismatch
+
+**Problem**: React Native R3F pointer events use `locationX`/`locationY`, not the web-standard `clientX`/`clientY`.
+
+**Symptom**: Touch handlers receive `undefined` coordinates, which breaks raycasting and orbit controls. The resulting broken interaction state can cascade into components re-rendering in ways that confuse R3F's cleanup, surfacing as a `__r3f` error even though the root issue is the touch coordinates.
+
+**Fix**:
+
+```tsx
+// ❌ WRONG - Works on web, undefined on React Native
+const x = e.nativeEvent.clientX;
+
+// ✅ CORRECT - React Native touch coordinates
+const x = (e as unknown as { locationX: number }).locationX;
+const y = (e as unknown as { locationY: number }).locationY;
+```
+
+### Root Cause 2: `useMemo` Returning a Three.js Object
+
+**Problem**: When `useMemo` returns a new Three.js object (Quaternion, Vector3, etc.) on re-render, the old object gets orphaned and R3F's cleanup fails trying to detach it.
+
+**Fix**: Return primitive arrays instead of Three.js objects:
+
+```tsx
+// ❌ WRONG - R3F tracks this Quaternion object
+const { quaternion } = useMemo(() => {
+  const quat = new Quaternion().setFromUnitVectors(yAxis, direction);
+  return { quaternion: quat };  // Three.js object returned
+}, [deps]);
+
+<mesh quaternion={quaternion} />
+
+// ✅ CORRECT - Primitive array, no object tracking
+const { quaternion } = useMemo(() => {
+  const quat = new Quaternion().setFromUnitVectors(yAxis, direction);
+  return { quaternion: [quat.x, quat.y, quat.z, quat.w] as [number, number, number, number] };
+}, [deps]);
+
+<mesh quaternion={quaternion} />
+```
+
+### Root Cause 3: Module-Level Shared Three.js Constants
+
+**Problem**: Module-level Three.js constants (e.g. `const Y_AXIS = new Vector3(0, 1, 0)`) are shared across every instance of a component. If R3F ends up tracking that shared object, multiple component instances interfere with each other's cleanup.
+
+**Symptom**: Intermittent `__r3f` errors, especially with multiple components of the same type on screen.
+
+**Fix**: Create Three.js objects inside functions, not at module level:
+
+```tsx
+// ❌ WRONG - Shared across all component instances
+const Y_AXIS = new ThreeVector3(0, 1, 0);
+
+export function MyComponent() {
+  const rotation = useMemo(() => {
+    // Uses shared Y_AXIS
+  }, []);
+}
+
+// ✅ CORRECT - Created fresh each time
+export function MyComponent() {
+  const rotation = useMemo(() => {
+    const yAxis = new ThreeVector3(0, 1, 0);  // Local to this call
+    // ...
+  }, []);
+}
+```
+
+### Root Cause 4: State Management Replacing Object References
+
+**Problem**: If state management (Zustand, Redux) replaces Vector3/Quaternion object references on every update instead of mutating them, R3F loses track of the objects it was monitoring.
+
+**Symptom**: `__r3f` errors during physics simulation or animation updates.
+
+**Fix**: Mutate existing objects in place rather than replacing them:
+
+```tsx
+// ❌ WRONG - Creates new object, breaks R3F tracking
+node.position = add(node.position, velocity);
+
+// ✅ CORRECT - Mutates existing object
+function setVector3(target: Vector3, source: Vector3) {
+  target.x = source.x;
+  target.y = source.y;
+  target.z = source.z;
+}
+setVector3(node.position, add(node.position, velocity));
 ```
 
 ## Issue: Performance Problems
@@ -386,7 +500,7 @@ function MemoryMonitor() {
 ## Platform Differences
 
 | Behavior | iOS | Android |
-|----------|-----|---------|
+| ---------- | ----- | --------- |
 | WebGL Version | ES 2.0/3.0 | ES 2.0/3.0 |
 | Max Texture Size | Device-dependent | Device-dependent |
 | Touch Latency | ~16ms | ~16ms |
@@ -454,7 +568,7 @@ function DebugPanel() {
 ## Quick Fixes Checklist
 
 | Problem | Quick Fix |
-|---------|-----------|
+| --------- | ----------- |
 | Blank screen | Add dimensions to parent View |
 | Black objects | Add ambient/point light |
 | Touch not working | Disable OrbitControls or add stopPropagation |
@@ -463,3 +577,4 @@ function DebugPanel() {
 | Simulator crash | Test on physical device |
 | Objects invisible | Check camera position and near/far planes |
 | Lines too thin | Use TubeGeometry or Line2 (WebGL 1px limit) |
+| `__r3f` deletion error | Mutate Three.js objects in place; avoid returning new Three.js objects from useMemo/module scope |

--- a/plugins/react-native-3d/skills/r3f-native-patterns/SKILL.md
+++ b/plugins/react-native-3d/skills/r3f-native-patterns/SKILL.md
@@ -38,6 +38,32 @@ config.resolver.sourceExts.push('cjs', 'mjs');
 module.exports = config;
 ```
 
+## Avoid Module-Level Three.js Objects
+
+**Warning**: Don't declare Three.js objects (Vector3, Quaternion, etc.) as module-level constants. R3F attaches internal `__r3f` tracking metadata to Three.js objects it manages; a shared module-level instance can end up tracked by multiple component instances at once, causing cross-instance interference and `Cannot delete property '__r3f' of undefined` errors during cleanup.
+
+```tsx
+// ❌ WRONG - Shared across all component instances
+const Y_AXIS = new THREE.Vector3(0, 1, 0);
+
+export function MyComponent() {
+  const rotation = useMemo(() => {
+    // Uses shared Y_AXIS - can cause __r3f tracking conflicts
+    return quaternionFromAxis(Y_AXIS);
+  }, []);
+}
+
+// ✅ CORRECT - Created fresh inside the function
+export function MyComponent() {
+  const rotation = useMemo(() => {
+    const yAxis = new THREE.Vector3(0, 1, 0);  // Local to this call
+    return quaternionFromAxis(yAxis);
+  }, []);
+}
+```
+
+See `debugging-3d-mobile` for the full `__r3f` deletion error writeup.
+
 ## Basic Canvas Setup
 
 ```tsx
@@ -175,6 +201,21 @@ useFrame((state) => {
   applyEffects();
 }, 1);
 ```
+
+## React Native Touch Coordinates
+
+**Callout**: When reading raw touch data off `nativeEvent` (e.g. inside `useThree`-driven pointer handling or custom gesture code), React Native uses `locationX`/`locationY` — not the web-standard `clientX`/`clientY`. Reading the web property silently yields `undefined` on device, which breaks raycasting and orbit controls.
+
+```tsx
+// ❌ WRONG - Works on web, undefined on React Native
+const x = e.nativeEvent.clientX;
+
+// ✅ CORRECT - React Native touch coordinates
+const x = (e as unknown as { locationX: number }).locationX;
+const y = (e as unknown as { locationY: number }).locationY;
+```
+
+See `touch-gesture-3d` for the full touch/gesture handling guide.
 
 ## Accessing Three.js State: useThree
 
@@ -360,7 +401,7 @@ function StandardLighting() {
 ### Light Types
 
 | Light | Use Case | Performance |
-|-------|----------|-------------|
+| ------- | ---------- | ------------- |
 | `ambientLight` | Base fill, no shadows | Cheapest |
 | `directionalLight` | Sun, parallel rays | Medium |
 | `pointLight` | Bulbs, omni-directional | Medium |
@@ -500,6 +541,30 @@ function OptimizedMesh({ color }) {
   return <mesh geometry={geometry} material={material} />;
 }
 ```
+
+### Primitive Arrays vs Three.js Objects in useMemo
+
+**Warning**: If a `useMemo` returns a Three.js object (Quaternion, Vector3, etc.) that gets passed as a prop, R3F attaches `__r3f` tracking metadata to it. A new object created on re-render orphans the old one, and R3F's cleanup effect can throw `Cannot delete property '__r3f' of undefined` trying to detach it. Return primitive arrays instead — they carry no object identity for R3F to track.
+
+```tsx
+// ❌ WRONG - R3F tracks this Quaternion object; new instance each recompute
+const { quaternion } = useMemo(() => {
+  const quat = new THREE.Quaternion().setFromUnitVectors(yAxis, direction);
+  return { quaternion: quat };  // Three.js object returned
+}, [deps]);
+
+<mesh quaternion={quaternion} />
+
+// ✅ CORRECT - Primitive array, no object tracking
+const { quaternion } = useMemo(() => {
+  const quat = new THREE.Quaternion().setFromUnitVectors(yAxis, direction);
+  return { quaternion: [quat.x, quat.y, quat.z, quat.w] as [number, number, number, number] };
+}, [deps]);
+
+<mesh quaternion={quaternion} />
+```
+
+See `debugging-3d-mobile` for the full `__r3f` deletion error writeup, including the state-management (Zustand/Redux) variant of this same problem.
 
 ### Conditional Rendering
 

--- a/plugins/react-native-3d/skills/touch-gesture-3d/SKILL.md
+++ b/plugins/react-native-3d/skills/touch-gesture-3d/SKILL.md
@@ -416,18 +416,19 @@ function DebugEventFlow({ children }) {
 ## Common Mistakes
 
 | Mistake | Fix |
-|---------|-----|
+| --------- | ----- |
 | Not calling `e.stopPropagation()` | Always stop propagation for handled events |
 | Using `onClick` instead of `onPointerDown` | `onPointerDown` is more reliable on mobile |
 | OrbitControls with default settings | Set `enabled={false}` when interacting with objects |
 | Invisible objects not receiving events | They need a material, even if transparent |
 | Lines not selectable | Call `computeLineDistances()` and set threshold |
 | Drag not working outside object bounds | Use `setPointerCapture`/`releasePointerCapture` |
+| Using `clientX`/`clientY` on React Native | Not available on RN — cast `e.nativeEvent` and read `locationX`/`locationY` instead; see `r3f-native-patterns` for the full example |
 
 ## Platform Differences
 
 | Behavior | iOS | Android |
-|----------|-----|---------|
+| ---------- | ----- | --------- |
 | Multi-touch | Works | Works |
 | Pointer capture | Supported | Supported |
 | Event timing | Slightly delayed | Immediate |


### PR DESCRIPTION
## Summary

Closes #3 by documenting the `Cannot delete property '__r3f' of undefined` error and its four root causes across the `react-native-3d` plugin's skills:

- **`debugging-3d-mobile/SKILL.md`**: new "Issue: Cannot delete property '__r3f' of undefined" section covering what the error looks like, why it happens (R3F's cleanup effect trying to delete tracking metadata off an orphaned/reference-changed Three.js object), and all four root causes/fixes (touch coordinate mismatch, `useMemo` returning Three.js objects, module-level shared Three.js constants, state management replacing object references). Also adds a Quick Fixes Checklist row and a flowchart branch pointing to the new section.
- **`r3f-native-patterns/SKILL.md`**: adds a "React Native Touch Coordinates" callout (`locationX`/`locationY` vs `clientX`/`clientY`), an "Avoid Module-Level Three.js Objects" warning near Basic Canvas Setup, and a "Primitive Arrays vs Three.js Objects in useMemo" subsection under Performance Patterns, each cross-linking back to the debugging skill.
- **`touch-gesture-3d/SKILL.md`**: adds a row to the Common Mistakes table for the `clientX`/`clientY` vs `locationX`/`locationY` issue, linking to `r3f-native-patterns` for the full example.

No version bump — `plugin.json` stays at 1.0.0 per the plan (doc-only addition).

## Content sourcing

This repository has no application code that reproduces these errors — it's a documentation/skill-only marketplace. The content in this PR is transcribed and condensed from the issue author's own first-hand debugging notes in #3 (root causes, symptoms, and before/after code fixes), not derived from an in-repo fix commit or independent reproduction. Code examples are taken near-verbatim from the issue body and adapted only to match each file's existing style conventions.

## Test plan

- [x] Verified all three SKILL.md files render correctly as Markdown (no build step in this repo)
- [x] Cross-references between the three skills are consistent (checked by local adversarial + codebase review hooks, both PASS)
- [x] `plugin.json` left unchanged at 1.0.0
- [x] Local pre-commit (markdownlint auto-fix) and pre-push (Semgrep + full-diff/codebase review) checks passed

Fixes #3