### PR TITLE
fix(ci): float reusable workflow ref to @v3 for security propagation

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -11,14 +11,21 @@ permissions:
   id-token: write
 
 jobs:
-  # Pinned to v3.1.0+, not a caller-level `if: github.actor !=
+  # Floating @v3, not a caller-level `if: github.actor !=
   # 'dependabot[bot]'` gate — a job-level `if:` prevents this job from
   # ever reporting on Dependabot PRs, which leaves a required status
-  # check permanently pending. v3.1.0+ skips Dependabot PRs from
-  # inside the job instead, so it still reports PASS. See
+  # check permanently pending. The reusable workflow skips Dependabot
+  # PRs from inside the job instead, so it still reports PASS. See
   # smartwatermelon/github-workflows#115/#117.
+  #
+  # @v3 tracks the v3 major and is maintained at >= v3.1.0, so the
+  # inside-the-job Dependabot skip above is always present. Floating the
+  # major is deliberate: security fixes propagate by repointing one tag
+  # in github-workflows instead of a PR in every consumer repo. The
+  # previous exact @v3.1.0 pin silently opted this repo out of the
+  # GHSA-8q5r-mmjf-575q remediation.
   claude-review:
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3.1.0
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:


### PR DESCRIPTION
## Active security exposure

This repo pins its Claude blocking-review caller at `@v3.1.0`. That tag is
immutable and predates the GHSA-8q5r-mmjf-575q fix, so it still resolves to
`anthropics/claude-code-action@26ec0412` = **v1.0.70, vulnerable**.

The fleet-wide remediation was performed by repointing the floating `v3` tag in
`smartwatermelon/github-workflows`. Because this repo referenced an exact tag
rather than the floating major, it never received that fix.

Verified:
- `@v3.1.0` serves `claude-code-action@26ec0412` (v1.0.70, vulnerable)
- `@v3` serves `claude-code-action@9d7150bc` (v1.0.193, patched)

## Change

Moves the reusable-workflow ref from `@v3.1.0` to `@v3`. Nothing else in the
file is touched.

## Why float the major tag

Floating `@v3` means future security fixes propagate by repointing one tag in
`github-workflows`, instead of requiring a PR in every consumer repo. That is
the intended fleet model — exact pins silently opted this repo out of
remediation for months.

## Notes

- Committed with `SKIP=zizmor`. The `unpinned-uses` finding on the tag ref is
  pre-existing and deliberate fleet policy (documented at `README.md:207` in
  `github-workflows`), not introduced here.
- `claude-review / run-review` is expected to report `pass` via the
  `workflow-self-modification` skip path, since this PR touches
  `.github/workflows/`.
